### PR TITLE
Update to handle poetry 1.8.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Features
 Installation
 ------------
 
-**Note:** Plugins work at Poetry with version 1.2.0 or above.
+**Note:** Plugins work at Poetry with version 1.8.3 or above.
 
 You can install plugin via ``poetry``
 

--- a/poetry_release/version.py
+++ b/poetry_release/version.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from poetry.core.semver.version import Version
+from poetry.core.constraints.version import Version
 from poetry.core.version.exceptions import InvalidVersion
 from poetry.core.version.pep440.segments import ReleaseTag
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,23 +6,22 @@ license = "MIT"
 authors = ["Denis Kayshev <topenkoff@gmail.com>"]
 readme = "README.rst"
 homepage = "https://github.com/topenkoff/poetry-release"
-repository = "https://github.com/topenkoff/poetry-release"
+repository = "https://github.com/swift-nav/poetry-release"
 
-packages = [
-    { include = "poetry_release"}
-]
+packages = [{ include = "poetry_release" }]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-poetry = "^1.2.0"
+python = "^3.10"
+poetry = "^1.8.3"
+pytest = "^8.3.2"
 
 [tool.poetry.plugins."poetry.application.plugin"]
 poetry-release = "poetry_release.plugin:ReleasePlugin"
 
 [tool.poetry-release]
 release-replacements = [
-    { file="CHANGELOG.md", pattern="\\[Unreleased\\]", replace="[{version}] - {date}" },
-    { file="CHANGELOG.md", pattern="\\(https://semver.org/spec/v2.0.0.html\\).", replace="(https://semver.org/spec/v2.0.0.html).\n\n## [Unreleased]"},
+    { file = "CHANGELOG.md", pattern = "\\[Unreleased\\]", replace = "[{version}] - {date}" },
+    { file = "CHANGELOG.md", pattern = "\\(https://semver.org/spec/v2.0.0.html\\).", replace = "(https://semver.org/spec/v2.0.0.html).\n\n## [Unreleased]" },
 ]
 release-commit-message = "Release {package_name} {version} 🎉🎉🎉"
 sign-commit = true
@@ -31,7 +30,6 @@ sign-tag = true
 [tool.poetry.dev-dependencies]
 mypy = "^1.0"
 isort = "^5.11"
-# flake8 = "^3.9"
 black = "^23.1"
 
 [tool.mypy]


### PR DESCRIPTION
## Rationale

This is Swift's fork of https://github.com/topenkoff/poetry-release, which is no longer maintained and only supports poetry until 1.5.1.

It's used by skylark-fault-injector, which is stuck with an old poetry because of that.
This PR enables using `poetry-release` with `poetry > 1.5.1` (currently poetry `1.8.3`):

* Applies changes mentionned  here https://github.com/topenkoff/poetry-release/issues/6#issuecomment-1709301656
* Fixes some more issues 


## Testing

Released skylark-fault-injector 1.5.0 with it
